### PR TITLE
Allow concatenation of String and Numeric

### DIFF
--- a/examples/numeric.proc
+++ b/examples/numeric.proc
@@ -1,2 +1,4 @@
 
 print(1);
+
+print("The number is:" ++ 2);

--- a/src/ProC/Language.hs
+++ b/src/ProC/Language.hs
@@ -8,6 +8,15 @@ module ProC.Language where
 
 import Control.Monad
 
+class ToString s where
+    toString :: s -> String
+    
+instance ToString String where
+    toString = id
+    
+instance ToString Integer where
+    toString = show
+
 class Eval exp res | exp -> res where
   eval :: exp -> res
 
@@ -16,19 +25,22 @@ data NumericExpression = IntLiteral Integer
 instance Eval NumericExpression Integer where
     eval (IntLiteral i) = i
 
-data StringExpression =
-  StringLiteral String | StringConcat StringExpression StringExpression
+data StringExpression where
+  StringFromNumericExpression :: NumericExpression -> StringExpression
+  StringLiteral :: String -> StringExpression
+  StringConcat :: StringExpression -> StringExpression -> StringExpression
 
 instance Eval StringExpression String where
     eval (StringLiteral s) = s
-    eval (StringConcat l r) = eval l ++ eval r
+    eval (StringConcat l r) = mconcat $ toString . eval <$> [l, r]
+    eval (StringFromNumericExpression n) = toString $ eval n
 
 data Statement where
     Noop :: Statement
-    Print :: (Eval e s, Show s) => e -> Statement
+    Print :: StringExpression -> Statement
     Seq :: [Statement] -> Statement
         
 exec :: Statement -> IO ()
 exec (Noop) = return ()
-exec (Print s) = putStrLn . show $ eval s
+exec (Print s) = putStrLn $ eval s
 exec (Seq ss) = forM_ ss exec

--- a/src/ProC/Parser/Statement.hs
+++ b/src/ProC/Parser/Statement.hs
@@ -2,14 +2,13 @@ module ProC.Parser.Statement where
 
 import ProC.Language
 import ProC.Parser.Lexer
-import ProC.Parser.NumericExpression
 import ProC.Parser.StringExpression
 
 import Text.Parsec
 import Text.Parsec.String
 
 printStatement :: Parser Statement
-printStatement = try (p stringExpression) <|> p numericExpression
+printStatement = p stringExpression
   where
     p expr = reserved "print" >> parens expr >>= return . Print
   

--- a/src/ProC/Parser/StringExpression.hs
+++ b/src/ProC/Parser/StringExpression.hs
@@ -2,6 +2,9 @@ module ProC.Parser.StringExpression where
 
 import ProC.Language
 import ProC.Parser.Lexer
+import ProC.Parser.NumericExpression (numericExpression)
+
+import Control.Applicative
 
 import Data.Functor.Identity
 
@@ -9,7 +12,10 @@ import Text.Parsec.Expr
 import Text.Parsec.String
 
 term :: Parser StringExpression
-term = StringLiteral <$> stringLiteral
+term = lit <|> num
+  where
+    lit = StringLiteral <$> stringLiteral
+    num = StringFromNumericExpression <$> numericExpression
 
 ops :: OperatorTable String () Identity StringExpression
 ops = [ [ Infix (reservedOp "++" >> return StringConcat) AssocLeft ] ]


### PR DESCRIPTION
Makes NumericExpression a StringExpression, which makes it usable in StringExpression